### PR TITLE
Devilstrand Colour Bundle

### DIFF
--- a/Patches/Devilstrand Colour Bundle/Items_Resources_Stuff.xml
+++ b/Patches/Devilstrand Colour Bundle/Items_Resources_Stuff.xml
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Devilstrand Colour Bundle</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+			
+			<!-- ==========  Devilstrand_Blue  =========== -->
+				
+				<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-B_DEVILSTRAND-B_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>
+			
+			<!-- ==========  Devilstrand_Cyan  =========== -->
+				
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-C_DEVILSTRAND-C_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>
+			
+			<!-- ==========  Devilstrand_Green  =========== -->
+				
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-G_DEVILSTRAND-G_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>
+			
+			<!-- ==========  Devilstrand_Pink  =========== -->
+				
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-K_DEVILSTRAND-K_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>
+			
+			<!-- ==========  Devilstrand_Orange  =========== -->
+				
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-O_DEVILSTRAND-O_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>
+			
+			<!-- ==========  Devilstrand_Purple  =========== -->
+				
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-P_DEVILSTRAND-P_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>
+			
+			<!-- ==========  Devilstrand_Yellow  =========== -->
+				
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/statBases</xpath>
+				<value>
+				<Bulk>0.3</Bulk>
+				<WornBulk>0.5</WornBulk>
+				</value>
+				</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/stuffProps/statFactors</xpath>
+				<value>
+					<Mass>0.95</Mass>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+				<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+				<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/statBases/StuffPower_Armor_Heat</xpath>
+				<value>
+				<StuffPower_Armor_Heat>0.05</StuffPower_Armor_Heat>
+				 <StuffPower_Armor_Electric>0.05</StuffPower_Armor_Electric>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/statBases/Flammability</xpath>
+				<value>
+				<Flammability>0</Flammability>
+				</value>
+			</li>
+			
+				<li Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/stuffProps/categories</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/stuffProps</xpath>
+			<value>
+				<categories>
+				  <li>SoftArmor</li>
+				</categories>
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="DS-Y_DEVILSTRAND-Y_CLOTH_DEF"]/stuffProps/categories</xpath>
+			<value>
+				<li>SoftArmor</li>
+			</value>
+		</match>
+			</li>			
+			
+		</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Additions

Makes a Patch for the Devilstrand CE Colour Bundle mod

Changes

All Devilstrand Colors added by the mod are brought in-line with the stats changed for vanilla Devilstrand

Reasoning

Using this mod without a patch makes it so that all of the devilstrand variants added by this mod retain their vanilla stats, thus making them multitudes stronger than all materials patched for Combat Extended. Vastly outperforming CE's Devilstrand and even eclipsing Hyperweave for all forms of protection.

Testing

Check tests you have performed:

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested long enough to verify all materials match CE Devilstrand stats for all colors. Including comparisons against vanilla and each other, and making clothes of all colors.
